### PR TITLE
Update to Ubuntu Chat processing

### DIFF
--- a/ubuntu/preprocess.py
+++ b/ubuntu/preprocess.py
@@ -101,7 +101,10 @@ class UbuntuChatParallel(ShardParallelProcessor):
             "",
             text,
         )
+        text = text.strip()
         # TODO: Check for min lines
+        if not text:
+            return None
         # Extract authors and action authors.
         # Look at the start of the line to avoid picking up authors that are quoted.
         authors = set(


### PR DESCRIPTION
The full data lives here https://huggingface.co/datasets/blester125/ubuntu-chat-dolma

 This PR updates the ubuntu processing to filter out empty chats, there were a lot of empty ones (happens when there aer no messages for a channel on some day).