### PR TITLE
Add json serialization for datetime in to_dolma

### DIFF
--- a/licensed_pile/write.py
+++ b/licensed_pile/write.py
@@ -23,12 +23,14 @@ def shard_name(filename: str, shard: str, padding: int = 5):
     """Convert a shard count into a name with leading zeros for easy sorting."""
     return f"{shard:>0{padding}}_{filename}"
 
+
 def serialize_datetime(obj):
     """Convert datetime.datetime to ISO format string for JSON serialization."""
     if isinstance(obj, datetime.datetime):
         return obj.isoformat()
     else:
         raise ValueError(f"Object of type {type(obj)} is not serializable.")
+
 
 # TODO: Add overwrite protection
 def to_dolma(

--- a/licensed_pile/write.py
+++ b/licensed_pile/write.py
@@ -2,6 +2,7 @@
 
 import abc
 import copy
+import datetime
 import json
 import logging
 import multiprocessing as mp
@@ -22,6 +23,12 @@ def shard_name(filename: str, shard: str, padding: int = 5):
     """Convert a shard count into a name with leading zeros for easy sorting."""
     return f"{shard:>0{padding}}_{filename}"
 
+def serialize_datetime(obj):
+    """Convert datetime.datetime to ISO format string for JSON serialization."""
+    if isinstance(obj, datetime.datetime):
+        return obj.isoformat()
+    else:
+        raise ValueError(f"Object of type {type(obj)} is not serializable.")
 
 # TODO: Add overwrite protection
 def to_dolma(
@@ -44,7 +51,7 @@ def to_dolma(
             smart_open.open(os.path.join(path, shard_name(filename, shard_idx)), "w")
         )
         for example in tqdm.tqdm(examples, disable=quiet):
-            data = json.dumps(example)
+            data = json.dumps(example, default=serialize_datetime)
             # Assume one character is about 1 bytes, good enough as we use utf-8
             size += len(data)
             if size >= max_bytes:


### PR DESCRIPTION
Some (but not all) of our datasets have a `created` field that is string date/time like `"2023-10-14T00:00:00"`. If I load the dataset with HF, the `created` field gets loaded as datetime, I guess because `datasets` is trying to be helpful. If I then call `to_dolma` directly with a `datasets.Dataset`, it mostly does what we want (because `datasets.Dataset` is just an iterable of dict-like objects), except that we call `json.dumps` on each dict yielded by the iterable -- since the dict contains a `datetime` object in the `created` field, json throws an error because it can't serialize `datatime`s. This PR adds a function that serializes datetimes to `json.dumps`.