### PR TITLE
Use GraphQL API

### DIFF
--- a/gharchive/scrape_licenses.py
+++ b/gharchive/scrape_licenses.py
@@ -39,7 +39,8 @@ def main():
                     i += 1
                     wait = max(60, wait // 8)
             except Exception as e:
-                if "API rate limit exceeded" in e.msg:
+                error = str(e)
+                if "API rate limit exceeded" in error:
                     wait = min(wait * 4, 60 * 60)
                     logger.info(f"API rate limit exceeded. Waiting {wait} seconds.")
                     time.sleep(wait)

--- a/gharchive/scrape_licenses.py
+++ b/gharchive/scrape_licenses.py
@@ -1,13 +1,16 @@
 """Populate the license cache from our data."""
 
 import argparse
+import asyncio
 import glob
 import itertools
 import json
+import os
 import shelve
 import time
 from datetime import datetime, timezone
 
+import httpx
 from dateutil.parser import parse
 from ghapi.all import GhApi
 from to_dolma import (
@@ -28,6 +31,66 @@ parser.add_argument(
 parser.add_argument(
     "--batch_size", help="Batch requests using GraphQL API.", required=False, default=200, type=int
 )
+parser.add_argument(
+    "--concurrent_batches", help="Number of concurrent", required=False, default=2, type=int
+)
+
+
+async def batch_main(args, logger, rate_limit, repos, license_cache) -> None:
+    i = 0
+    if args.batch_size > 1:
+        async with httpx.AsyncClient(
+                timeout=httpx.Timeout(30.0),
+                limits=httpx.Limits(max_keepalive_connections=args.concurrent_batches, max_connections=args.concurrent_batches),
+                headers={
+                    "User-Agent": "GitHub-License-Checker",
+                    "Authorization": f"token {os.environ['GITHUB_TOKEN']}"
+                }
+        ) as client:
+            while i < len(repos):
+                # Check if we need to wait for rate limit reset
+                if rate_limit and rate_limit["remaining"] < args.batch_size:
+                    logger.info(
+                        f"Rate limit is low, {rate_limit['remaining']}. Waiting until {rate_limit['resetAt']}."
+                    )
+                    reset_time = parse(rate_limit["resetAt"])
+                    sleep_seconds = (
+                        reset_time - datetime.now(timezone.utc)
+                    ).total_seconds()
+                    if sleep_seconds > 0:
+                        await asyncio.sleep(sleep_seconds)
+
+                # Create batches, up to concurrent_batches
+                batches = []
+                current_index = i
+
+                while (
+                    current_index < len(repos)
+                    and len(batches) < args.concurrent_batches
+                ):
+                    batch_end = min(current_index + args.batch_size, len(repos))
+                    batch = repos[current_index:batch_end]
+                    batches.append(
+                        batched_get_license_info(
+                            batch,
+                            license_cache,
+                            client=client,
+                            rate_limit=rate_limit,
+                        )
+                    )
+                    current_index = batch_end
+
+                # Wait for all batches to complete
+                batch_results = await asyncio.gather(*batches)
+
+                # Update rate limit from the last result
+                for result in batch_results:
+                    *_, batch_rate_limit = result
+                    rate_limit = batch_rate_limit
+
+                # Update index to the new position
+                i = current_index
+
 
 def main():
     args = parser.parse_args()
@@ -42,28 +105,7 @@ def main():
         rate_limit = check_github_graphql_rate_limit() if args.batch_size > 1 else None
         logger.info(f"Rate limit: {rate_limit}")
         if args.batch_size > 1:
-            while i < len(repos):
-                # Check if we need to wait for rate limit reset
-                if rate_limit and rate_limit["remaining"] < args.batch_size:
-                    logger.info(
-                        f"Rate limit is low, {rate_limit['remaining']}. Waiting until {rate_limit['resetAt']}."
-                    )
-                    reset_time = parse(rate_limit["resetAt"])
-                    sleep_seconds = (
-                        reset_time - datetime.now(timezone.utc)
-                    ).total_seconds()
-                    if sleep_seconds > 0:
-                        time.sleep(sleep_seconds)
-
-                batch_size = min(args.batch_size, len(repos) - i)
-
-                if batch_size > 0:
-                    *_, rate_limit = batched_get_license_info(
-                        repos[i : i + batch_size], license_cache, rate_limit=rate_limit
-                    )
-                    i += batch_size
-                else:
-                    break
+            asyncio.run(batch_main(args, logger, rate_limit, repos, license_cache))
         else:
             while True:
                 while api.limit_rem == 0:

--- a/gharchive/scrape_licenses.py
+++ b/gharchive/scrape_licenses.py
@@ -6,9 +6,18 @@ import itertools
 import json
 import shelve
 import time
+from datetime import datetime, timezone
 
+from dateutil.parser import parse
 from ghapi.all import GhApi
-from to_dolma import LicenseInfo, LicenseSnapshot, get_license_info, read_threads
+from to_dolma import (
+    LicenseInfo,
+    LicenseSnapshot,
+    get_license_info,
+    read_threads,
+    check_github_graphql_rate_limit,
+    batched_get_license_info,
+)
 
 from licensed_pile import logs
 
@@ -16,7 +25,9 @@ parser = argparse.ArgumentParser(description="Scrape Licenses.")
 parser.add_argument(
     "--repo_list", help="Path to a file that has a list of repos (JSON).", required=True
 )
-
+parser.add_argument(
+    "--batch_size", help="Batch requests using GraphQL API.", required=False, default=200, type=int
+)
 
 def main():
     args = parser.parse_args()
@@ -27,26 +38,53 @@ def main():
     wait = 60
     with shelve.open(f"{args.repo_list}.licenses") as license_cache:
         i = 0
-        while True:
-            while api.limit_rem == 0:
-                logger.info(f"Waiting as API quota is low, {api.limit_rem}.")
-                time.sleep(1)
-            try:
-                with logger(repo=repos[i], i=i):
-                    _ = get_license_info(
-                        repos[i], license_cache, api, fetch_license=True
+        # Initial rate limit check only needed for the first iteration
+        rate_limit = check_github_graphql_rate_limit() if args.batch_size > 1 else None
+        logger.info(f"Rate limit: {rate_limit}")
+        if args.batch_size > 1:
+            while i < len(repos):
+                # Check if we need to wait for rate limit reset
+                if rate_limit and rate_limit["remaining"] < args.batch_size:
+                    logger.info(
+                        f"Rate limit is low, {rate_limit['remaining']}. Waiting until {rate_limit['resetAt']}."
                     )
-                    i += 1
-                    wait = max(60, wait // 8)
-            except Exception as e:
-                error = str(e)
-                if "API rate limit exceeded" in error:
-                    wait = min(wait * 4, 60 * 60)
-                    logger.info(f"API rate limit exceeded. Waiting {wait} seconds.")
-                    time.sleep(wait)
+                    reset_time = parse(rate_limit["resetAt"])
+                    sleep_seconds = (
+                        reset_time - datetime.now(timezone.utc)
+                    ).total_seconds()
+                    if sleep_seconds > 0:
+                        time.sleep(sleep_seconds)
+
+                batch_size = min(args.batch_size, len(repos) - i)
+
+                if batch_size > 0:
+                    *_, rate_limit = batched_get_license_info(
+                        repos[i : i + batch_size], license_cache, rate_limit=rate_limit
+                    )
+                    i += batch_size
                 else:
-                    logger.exception(f"Failed to process {repos[i]}, skipping")
-                    i += 1
+                    break
+        else:
+            while True:
+                while api.limit_rem == 0:
+                    logger.info(f"Waiting as API quota is low, {api.limit_rem}.")
+                    time.sleep(1)
+                try:
+                    with logger(repo=repos[i], i=i):
+                        _ = get_license_info(
+                            repos[i], license_cache, api, fetch_license=True
+                        )
+                        i += 1
+                        wait = max(60, wait // 8)
+                except Exception as e:
+                    error = str(e)
+                    if "API rate limit exceeded" in error:
+                        wait = min(wait * 4, 60 * 60)
+                        logger.info(f"API rate limit exceeded. Waiting {wait} seconds.")
+                        time.sleep(wait)
+                    else:
+                        logger.exception(f"Failed to process {repos[i]}, skipping")
+                        i += 1
 
 
 if __name__ == "__main__":

--- a/gharchive/to_dolma.py
+++ b/gharchive/to_dolma.py
@@ -157,6 +157,7 @@ def batched_get_license_info(
     rate_limit=None,
     max_retries=3,
     retry_delay=2,
+    timeout=20,
     **kwargs,
 ) -> Optional[Tuple[list[LicenseInfo], dict, Union[dict, None]]]:
     logger = logs.get_logger()
@@ -176,7 +177,10 @@ def batched_get_license_info(
     while retries <= max_retries:
         try:
             response = requests.post(
-                "https://api.github.com/graphql", json={"query": full_query}, headers=headers
+                "https://api.github.com/graphql",
+                json={"query": full_query},
+                headers=headers,
+                timeout=timeout,
             ).json()
             for r in response["data"]:
                 if r == "rateLimit":

--- a/gharchive/to_dolma.py
+++ b/gharchive/to_dolma.py
@@ -9,10 +9,12 @@ import json
 import os
 import re
 import shelve
+import time
 from datetime import datetime
-from typing import Iterator, Optional, Sequence
+from typing import Iterator, Optional, Sequence, Tuple, Union
 
 import bs4
+import requests
 import smart_open
 from ghapi.all import GhApi
 from ghapi.core import (
@@ -87,6 +89,158 @@ class LicenseInfo:
             if l.active(time):
                 return True
         return False
+
+def build_graphql_query(repos: list[str]) -> Tuple[list[str], dict]:
+    query_parts = []
+    index = {}
+    for idx, repo in enumerate(repos):
+        owner, name = repo.split("/")
+        alias = f"repo{idx + 1}"
+        index[alias] = repo
+        query_parts.append(f"""
+        {alias}: repository(owner: "{owner}", name: "{name}") {{
+            name
+            owner {{
+                login
+            }}
+            licenseInfo {{
+                spdxId
+                name
+                url
+                key
+                id
+            }}
+        }}
+        """)
+    query_parts.append("""
+    rateLimit {
+        cost
+        remaining
+        resetAt
+    }
+    """)
+    return query_parts, index
+
+def check_github_graphql_rate_limit():
+    logger = logs.get_logger()
+    query = """
+    query {
+      rateLimit {
+        limit
+        cost
+        remaining
+        resetAt
+      }
+    }
+    """
+
+    response = requests.post(
+        "https://api.github.com/graphql",
+        json={"query": query},
+        headers={
+            "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+            "Content-Type": "application/json",
+        },
+    )
+
+    if response.status_code == 200:
+        data = response.json()
+        return data["data"]["rateLimit"]
+    else:
+        logger.error(f"Error: {response.status_code}, {response.text}")
+        return None
+
+
+def batched_get_license_info(
+    repos: list[str],
+    license_cache,
+    rate_limit=None,
+    max_retries=3,
+    retry_delay=2,
+    **kwargs,
+) -> Optional[Tuple[list[LicenseInfo], dict, Union[dict, None]]]:
+    logger = logs.get_logger()
+    res = []
+    if isinstance(repos, str):
+        repos = [repos]
+    alpha = datetime(1900, 1, 1)
+    omega = datetime(9999, 1, 1)
+    queries = [repo for repo in repos if repo not in license_cache]
+    if not queries:
+        logger.info("cache hit, reusing past license info")
+        return [], {}, rate_limit
+    queries_, index = build_graphql_query(queries)
+    full_query = "query {" + "\n".join(queries_) + "\n}"
+    headers = {"Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}"}
+    retries = 0
+    while retries <= max_retries:
+        try:
+            response = requests.post(
+                "https://api.github.com/graphql", json={"query": full_query}, headers=headers
+            ).json()
+            for r in response["data"]:
+                if r == "rateLimit":
+                    rate_limit = response["data"]["rateLimit"]
+                else:
+                    repo = response["data"][r]
+                    if repo is None:
+                        license_info = LicenseInfo(
+                            licenses=[
+                                LicenseSnapshot(license="unlicensed", start=alpha, end=omega)
+                            ],
+                            license_type="restrictive",
+                        )
+                    else:
+                        license = repo.get("licenseInfo", None)
+                        if license:
+                            license_info = (
+                                LicenseInfo(
+                                    licenses=[
+                                        LicenseSnapshot(
+                                            license=repo["licenseInfo"]["spdxId"],
+                                            start=alpha,
+                                            end=omega,
+                                        )
+                                    ]
+                                )
+                                if license.get("spdxId")
+                                else LicenseInfo(
+                                    licenses=[
+                                        LicenseSnapshot(
+                                            license="unlicensed", start=alpha, end=omega
+                                        )
+                                    ],
+                                    license_type="restrictive",
+                                )
+                            )
+                        else:
+                            license_info = LicenseInfo(
+                                licenses=[
+                                    LicenseSnapshot(
+                                        license="unlicensed", start=alpha, end=omega
+                                    )
+                                ],
+                                license_type="restrictive",
+                            )
+
+                    license_cache[index[r]] = license_info
+                    res.append(license_info)
+
+            logger.info(
+                f"Fetching license info for {len(queries)} repos. Cost: {response['data']['rateLimit']['cost']}. Remaining: {response['data']['rateLimit']['remaining']}."
+            )
+            return res, index, rate_limit
+
+        except Exception as e:
+            if retries == max_retries:
+                logger.error(f"Max retries reached. Last error: {e}")
+                raise e
+            logger.info("Error. Retrying")
+            retries += 1
+            logger.warning(
+                f"Error occurred: {e}. Retrying ({retries}/{max_retries}) in {retry_delay} seconds..."
+            )
+            time.sleep(retry_delay)
 
 
 def get_license_info(

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ charset_normalizer
 contextual-logger>=0.0.2
 datasets
 python-dateutil
+httpx
 dolma
 ghapi
 google-cloud-storage

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ beautifulsoup4
 charset_normalizer
 contextual-logger>=0.0.2
 datasets
+python-dateutil
 dolma
 ghapi
 google-cloud-storage


### PR DESCRIPTION
The GraphQL API supports request batching, which is a bit faster but more importantly multiplies our rate limit capacity, as each batched group counts as one request against the limit.

Note: Setting `--batch_size` to 200 works fine on my end, but increasing it beyond that returns errors.

edit: using concurrent requests, although only max of 2 seem to be stable. `shelf` isn't really concurrent-safe but seems to be working ok