### PR TITLE
Fix arXiv LaTeX parsing edge cases and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ If you are looking for the data itself or our trained models, please see [our Hu
 ## Installation
 
 The majority of packages required for dataset creation can be installed with `pip install -r requirements.txt`.
-To make use of the shared functionality in the `common_pile` pckage, run `pip install -e .`.
-If you are on a system that doesn't support automatic installation of pandoc with `pypandoc_binary`, change it to `pypandoc` in the `requirements.txt` and and install pandoc manually.
+To make use of the shared functionality in the `common_pile` package, run `pip install -e .`.
+If you are on a system that doesn't support automatic installation of pandoc with `pypandoc_binary`, change it to `pypandoc` in the `requirements.txt` and install pandoc manually.
 
 ## Contributing
 
@@ -26,5 +26,5 @@ The [scripts subdirectory](https://github.com/r-three/common-pile/tree/main/comm
 Alternatively, the Dolma-formatted files can be inspected with [`jq`](https://jqlang.org/) by running
 
 ```
-cat ${file}.jsonl.gz | gunzip | jq -s ${commmand}
+cat ${file}.jsonl.gz | gunzip | jq -s ${command}
 ```

--- a/sources/arxiv/from_latex/README.md
+++ b/sources/arxiv/from_latex/README.md
@@ -9,7 +9,7 @@ benefits.
 1. Setup credentials for boto3 as the arxiv s3 buckets are requester pays.
 2. Run `python bulk_download.py --download_old --download_manifest`
 3. Run `extract.sh`
-4. Download metadata from https://www.kaggle.com/datasets/Cornell-University/arxiv. We use this metadate over a manual scrape of the oai2 end point with a tool like metha as the kaggle dump has license information as a field instead of trying to parse it out of a `<dc:description>` field. The Kaggle dump is updated ~weekly, for example on 2024/01/13, the most recent paper was from 2024/01/05.
+4. Download metadata from https://www.kaggle.com/datasets/Cornell-University/arxiv. We use this metadata over a manual scrape of the oai2 endpoint with a tool like metha as the kaggle dump has license information as a field instead of trying to parse it out of a `<dc:description>` field. The Kaggle dump is updated ~weekly, for example on 2024/01/13, the most recent paper was from 2024/01/05.
 5. Extract the downloaded metadata `unzip arxiv-metadata-oai-snapshot.json.zip`
 6. Run `python to-dolma.py`. This will download required bulk download shards as needed. As only ~15% of the articles are CC licensed, there is a lot of possible saving by not pre-downloading everything.
 7. Run `python preprocess.py`. This will parse the latex into more readable plain text. The math is left as it. Currently section and citation references are not handled that well.

--- a/sources/arxiv/from_latex/get-data.sh
+++ b/sources/arxiv/from_latex/get-data.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-python buld_download.py --download_old --download_manifest
+python bulk_download.py --download_old --download_manifest
 extract.sh
-unzip data/arxiv-metadata-oat-snapshot.json.zip
+unzip data/arxiv-metadata-oai-snapshot.json.zip
 python to-dolma.py
 python preprocess.py

--- a/sources/arxiv/from_latex/to-dolma.py
+++ b/sources/arxiv/from_latex/to-dolma.py
@@ -82,7 +82,51 @@ def skip_file(filename: str, to_skip: Set[str]) -> bool:
       Sometimes people use \input{filename} or \input{filename.tex}
       to include other files in latex.
     """
-    return filename in to_skip or os.path.splitext(filename)[0] in to_skip
+    skipped = {f.lower() for f in to_skip}
+    return (
+        filename.lower() in skipped
+        or os.path.splitext(filename)[0].lower() in skipped
+    )
+
+
+def is_commented_out(contents: str, position: int) -> bool:
+    r"""Check whether position is after an unescaped `%` on the same line."""
+    line_start = contents.rfind("\n", 0, position) + 1
+    prefix = contents[line_start:position]
+    escaped = False
+    for char in prefix:
+        if char == "\\":
+            escaped = not escaped
+            continue
+        if char == "%" and not escaped:
+            return True
+        escaped = False
+    return False
+
+
+def get_tex_member(tar, filename: str):
+    """Find a TeX member, allowing omitted extensions and case variants."""
+    filename = filename.strip()
+    stem, extension = os.path.splitext(filename)
+    if extension:
+        candidates = [filename]
+        if extension.lower() == ".tex":
+            candidates.append(f"{stem}.tex")
+    else:
+        candidates = [f"{filename}.tex"]
+
+    for candidate in candidates:
+        try:
+            return tar.getmember(candidate)
+        except KeyError:
+            pass
+
+    lowercase_candidates = {candidate.lower() for candidate in candidates}
+    for member in tar.getmembers():
+        if member.name.lower() in lowercase_candidates:
+            return member
+
+    raise KeyError(f"No TeX member found for {filename}")
 
 
 def read_file(tar, file_info, article_id: str):
@@ -107,7 +151,10 @@ def interpolate_document(
     logger = logs.get_logger("arxiv")
 
     # Capture the whole command so we know the bounds and can remove it.
-    for m in re.finditer(r"(?P<cmd>\\input{(?P<filename>.*?)})", contents):
+    input_pattern = r"(?P<cmd>\\(?:input|include)\s*\{(?P<filename>.*?)\})"
+    for m in re.finditer(input_pattern, contents):
+        if is_commented_out(contents, m.start()):
+            continue
         # Add everything before the \input command.
         full_contents.append(contents[offset : m.start()])
         offset = m.end()
@@ -117,15 +164,14 @@ def interpolate_document(
         # skip this as it seems complex. Unsure how many documents include the
         # \import or \subimport command
         try:
-            input_file = tar.getmember(
-                f"{os.path.splitext(m.group('filename'))[0]}.tex"
-            )
+            input_file = get_tex_member(tar, m.group("filename"))
             input_contents = read_file(tar, input_file, article_id)
             logger.debug(f"Interpolating {m.group('filename')} into {article_id}")
             full_contents.append(input_contents)
             # Track which files we have interpolated into other documents to avoid
             # using them as top-level documents.
             skip.add(m.group("filename"))
+            skip.add(input_file.name)
         except Exception as e:
             logger.warning(
                 f"Failed to interpolate {m.group('filename')} while processing [{article_id}]: {e}"
@@ -160,11 +206,11 @@ def load_article_src(article_path: str, article_id: str) -> str:
                         continue
                     # If the file is a .tex document and it isn't in a directory.
                     if (
-                        os.path.splitext(info.name)[1] == ".tex"
+                        os.path.splitext(info.name)[1].lower() == ".tex"
                         and os.path.dirname(info.name) == ""
                     ):
                         logger.debug(
-                            f"Creating a document from {article_id}/{info.name}t"
+                            f"Creating a document from {article_id}/{info.name}"
                         )
                         contents = read_file(tar, info, article_id)
                         # Only output files that include \begin{document}. If
@@ -179,9 +225,11 @@ def load_article_src(article_path: str, article_id: str) -> str:
             logger.debug(f"Creating a document from single file for {article_id}")
             with gzip.open(article_path) as f:
                 contents = f.read()
+            if isinstance(contents, bytes):
+                contents = str(from_bytes(contents).best())
             # If the file isn't a tarball, then it won't have any extra files
             # that are `\input`ed.
-            yield content, None
+            yield contents, None
     except Exception as e:
         logger.warning(
             f"Failed to load article [{article_id}] at `{article_path}`: {e}"
@@ -194,7 +242,7 @@ def format_dolma(article, text: str, source: str = SOURCE_NAME):
         "id": article["id"],
         "text": text,
         "source": "arxiv",
-        "added": datetime.datetime.utcnow().isoformat(),
+        "added": datetime.datetime.now(datetime.timezone.utc).isoformat(),
         "created": article["update_date"],
         "metadata": {
             "license": str(LICENSES.get(article["license"], article["license"])),

--- a/sources/arxiv/from_latex/to-dolma.py
+++ b/sources/arxiv/from_latex/to-dolma.py
@@ -212,7 +212,7 @@ def process_article(
     # The bulk downloader is smart enough to only download dirs when it needs
     # it so we can just call `.download` on all articles and know that it
     # won't keep re-downloading things.
-    # The start and end fields of the shards use the same verions of ids as
+    # The start and end fields of the shards use the same versions of ids as
     # filenames, that is, without the `/`
     bulk_downloader.download(id_to_filename(article["id"]))
     article_path = os.path.join(

--- a/sources/arxiv/from_latex/to_dolma_test.py
+++ b/sources/arxiv/from_latex/to_dolma_test.py
@@ -1,0 +1,124 @@
+"""Tests for arXiv source conversion."""
+
+import gzip
+import importlib.util
+import io
+import sys
+import tarfile
+import types
+from pathlib import Path
+
+
+MODULE_DIR = Path(__file__).parent
+sys.path.insert(0, str(MODULE_DIR))
+SPEC = importlib.util.spec_from_file_location("to_dolma", MODULE_DIR / "to-dolma.py")
+to_dolma = importlib.util.module_from_spec(SPEC)
+
+
+class Logger:
+    def debug(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+
+class BulkDownloader:
+    pass
+
+
+def load_to_dolma_module():
+    modules = {
+        "bulk_download": types.ModuleType("bulk_download"),
+        "common_pile": types.ModuleType("common_pile"),
+        "common_pile.logs": types.ModuleType("common_pile.logs"),
+        "common_pile.licenses": types.ModuleType("common_pile.licenses"),
+        "common_pile.write": types.ModuleType("common_pile.write"),
+    }
+    modules["bulk_download"].BulkDownloader = BulkDownloader
+    modules["common_pile.logs"].get_logger = lambda *args, **kwargs: Logger()
+    modules["common_pile.logs"].configure_logging = lambda *args, **kwargs: None
+    modules["common_pile"].logs = modules["common_pile.logs"]
+    modules["common_pile.licenses"].PermissiveLicenses = types.SimpleNamespace(
+        CC_BY_SA="CC_BY_SA",
+        CC_BY_3="CC_BY_3",
+        CC_BY="CC_BY",
+        PD="PD",
+        CC0="CC0",
+    )
+    modules["common_pile.write"].to_dolma = lambda *args, **kwargs: None
+
+    previous_modules = {name: sys.modules.get(name) for name in modules}
+    sys.modules.update(modules)
+    try:
+        SPEC.loader.exec_module(to_dolma)
+    finally:
+        for name, module in previous_modules.items():
+            if module is None:
+                del sys.modules[name]
+            else:
+                sys.modules[name] = module
+
+
+load_to_dolma_module()
+
+
+def add_text_file(tar, name: str, text: str):
+    data = text.encode("utf-8")
+    info = tarfile.TarInfo(name)
+    info.size = len(data)
+    tar.addfile(info, io.BytesIO(data))
+
+
+def test_is_commented_out_ignores_escaped_percent():
+    contents = r"\% \input{section}"
+    assert not to_dolma.is_commented_out(contents, contents.index(r"\input"))
+
+
+def test_is_commented_out_detects_percent_on_same_line():
+    contents = r"Some text % \input{section}"
+    assert to_dolma.is_commented_out(contents, contents.index(r"\input"))
+
+
+def test_load_article_src_handles_uppercase_tex_and_commented_input(tmp_path):
+    article_path = tmp_path / "article.gz"
+    main = "\n".join(
+        [
+            r"\begin{document}",
+            "Intro",
+            r"% \input{commented}",
+            r"\input{included}",
+            r"\end{document}",
+        ]
+    )
+    with tarfile.open(article_path, "w:gz") as tar:
+        add_text_file(tar, "main.TEX", main)
+        add_text_file(tar, "commented.tex", "Commented input should not be inserted.")
+        add_text_file(tar, "included.TEX", "Included text.")
+
+    documents = list(to_dolma.load_article_src(str(article_path), "1234.5678"))
+
+    assert documents == [
+        (
+            "\n".join(
+                [
+                    r"\begin{document}",
+                    "Intro",
+                    r"% \input{commented}",
+                    "Included text.",
+                    r"\end{document}",
+                ]
+            ),
+            "main.TEX",
+        )
+    ]
+
+
+def test_load_article_src_decodes_single_gzip_file(tmp_path):
+    article_path = tmp_path / "article.gz"
+    with gzip.open(article_path, "wb") as f:
+        f.write(b"plain gzip contents")
+
+    documents = list(to_dolma.load_article_src(str(article_path), "1234.5678"))
+
+    assert documents == [("plain gzip contents", None)]


### PR DESCRIPTION
Fixes a few edge cases in the arXiv LaTeX-to-Dolma conversion pipeline:

  - handle `.TEX` files case-insensitively
  - no interpolating for `\input{...}` / `\include{...}` commands that are
  commented out
  - resolve included TeX files case-insensitively and with omitted `.tex`
  extensions
  - fix the single-file gzip path to yield decoded contents instead of an
  undefined variable
  - replace deprecated `datetime.utcnow()`, still maintaining compatibility with Python 3.8
  - fix a few documentation/script typos, including the arXiv metadata
  filename and `bulk_download.py`

Closes #139.